### PR TITLE
fix: Ignore CHANGELOG.md in release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - main
+    paths-ignore:
+      - 'CHANGELOG.md'
   workflow_dispatch:      
 
 permissions:


### PR DESCRIPTION
Ignore changes to CHANGELOG.md in release-drafter workflow, to prevent another draft release after merging a PR.